### PR TITLE
cleanup of imports

### DIFF
--- a/pysal/contrib/viz/color.py
+++ b/pysal/contrib/viz/color.py
@@ -2,11 +2,6 @@
 color handling for mapping and geovisualization
 """
 
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
-import matplotlib.colors as mpc
-
-
 
 try:
     import palettable as pltt


### PR DESCRIPTION
Part of the push to clean up: Removing imports that were needed when using brewer2mpl.

"Requirement to jupyter nbconvert --execute geotable_plot.ipynb and have that run smoothly before pushing any changes" is a great idea.

It runs smoothly after these changes.
