### PR TITLE
add check for k exceeding the number of available palettable colors

### DIFF
--- a/pysal/contrib/viz/mapping.py
+++ b/pysal/contrib/viz/mapping.py
@@ -611,6 +611,10 @@ def geoplot(db, col=None, palette='BuGn', classi='Quantiles',
                   Additional named vaues to be passed to the classifier of choice.
     '''
     if col:
+        if hasattr(palette, 'number') and 'k' in kwargs:
+            if kwargs['k'] > palette.number:
+                raise ValueError('The number of classes requested is greater than '
+                                 'the number of colors available in the palette.')
         lbl,c = value_classifier(db[col], scheme=classi, **kwargs)
         if type(palette) is not str:
             palette = get_color_map(palette=palette, k=c.k)


### PR DESCRIPTION
It seems like you don't need any checks if the number of classes requested is smaller than the number of available colors. 

If it's larger, though, we should raise, since it currently just silently recycles the colors. This raises if a palette with a fixed number of colors is provided *and* `k` is explicitly requested to be larger than that fixed number of colors.  